### PR TITLE
Addresses issue of missing messages

### DIFF
--- a/fabric_mb/__init__.py
+++ b/fabric_mb/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.1b3"
+__VERSION__ = "1.1b4"

--- a/fabric_mb/__init__.py
+++ b/fabric_mb/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.1b2"
+__VERSION__ = "1.1b3"

--- a/fabric_mb/__init__.py
+++ b/fabric_mb/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.1b1"
+__VERSION__ = "1.1b2"

--- a/fabric_mb/message_bus/abc_mb_api.py
+++ b/fabric_mb/message_bus/abc_mb_api.py
@@ -23,42 +23,26 @@
 #
 #
 # Author: Komal Thareja (kthare10@renci.org)
+import logging
+import traceback
+from abc import ABC
 
-"""
-Base class
-"""
 
+class ABCMbApi(ABC):
+    def __init__(self, *, logger: logging.Logger = None):
+        if logger is None:
+            self.logger = logging.getLogger(__name__)
+            logging.basicConfig(level=logging.DEBUG,
+                                format="%(asctime)s [%(filename)s:%(lineno)d] [%(levelname)s] %(message)s",
+                                handlers=[logging.StreamHandler()])
 
-class Base:
-    """
-    Base class
-    """
-    def __init__(self, logger=None):
-        self.logger = logger
-
-    def log_debug(self, message: str):
-        """
-        Log a debug message
-        """
-        if self.logger is None:
-            print(message)
-        else:
-            self.logger.debug(message)
-
-    def log_error(self, message: str):
-        """
-        Log an error message
-        """
-        if self.logger is None:
-            print(message)
-        else:
-            self.logger.error(message)
-
-    def log_info(self, message: str):
-        """
-        Log an info message
-        """
-        if self.logger is None:
-            print(message)
-        else:
-            self.logger.info(message)
+    def load_schema(self, schema_file: str):
+        try:
+            from confluent_kafka import avro
+            file = open(schema_file, "r")
+            schema_bytes = file.read()
+            file.close()
+            return avro.loads(schema_bytes)
+        except Exception as e:
+            self.logger.error(f"Exception occurred while loading the schema: {schema_file}: {e}")
+            self.logger.error(traceback.format_exc())

--- a/fabric_mb/message_bus/abc_mb_api.py
+++ b/fabric_mb/message_bus/abc_mb_api.py
@@ -30,6 +30,7 @@ from abc import ABC
 
 class ABCMbApi(ABC):
     def __init__(self, *, logger: logging.Logger = None):
+        self.logger = logger
         if logger is None:
             self.logger = logging.getLogger(__name__)
             logging.basicConfig(level=logging.DEBUG,

--- a/fabric_mb/message_bus/messages/reservation_state_avro.py
+++ b/fabric_mb/message_bus/messages/reservation_state_avro.py
@@ -93,8 +93,8 @@ class ReservationStateAvro:
 
         return {
             'rid': self.rid,
-            'name':self.name,
-            'state':self.state,
+            'name': self.name,
+            'state': self.state,
             'pending_state': self.pending_state}
 
     def __str__(self):

--- a/fabric_mb/message_bus/producer.py
+++ b/fabric_mb/message_bus/producer.py
@@ -26,33 +26,50 @@
 """
 Defines AvroProducer API class which exposes interface for various producer functions
 """
+import logging
 import traceback
 
 from confluent_kafka.avro import AvroProducer
 
+from fabric_mb.message_bus.abc_mb_api import ABCMbApi
 from fabric_mb.message_bus.admin import AdminApi
-from fabric_mb.message_bus.base import Base
+from fabric_mb.message_bus.messages.auth_avro import AuthAvro
 from fabric_mb.message_bus.messages.query_avro import QueryAvro
 from fabric_mb.message_bus.messages.query_result_avro import QueryResultAvro
 from fabric_mb.message_bus.messages.message import IMessageAvro
 
 
-class AvroProducerApi(Base):
+class AvroProducerApi(ABCMbApi):
     """
         This class implements the Interface for Kafka producer carrying Avro messages.
         It is expected that the users would extend this class and override on_delivery function.
     """
-    def __init__(self, conf, key_schema, record_schema, logger=None):
+    def __init__(self, *, producer_conf: dict, key_schema_location, value_schema_location: str,
+                 logger: logging.Logger = None):
         """
             Initialize the Producer API
-            :param conf: configuration e.g:
+            :param producer_conf: configuration e.g:
                         {'bootstrap.servers': localhost:9092,
                         'schema.registry.url': http://localhost:8083}
-            :param key_schema: loaded AVRO schema for the key
-            :param record_schema: loaded AVRO schema for the value
+            :param key_schema_location: AVRO schema location for the key
+            :param value_schema_location: AVRO schema location for the value
         """
-        super().__init__(logger)
-        self.producer = AvroProducer(conf, default_key_schema=key_schema, default_value_schema=record_schema)
+        super().__init__(logger=logger)
+        self.key_schema = self.load_schema(schema_file=key_schema_location)
+        self.value_schema = self.load_schema(schema_file=value_schema_location)
+        self.producer = AvroProducer(producer_conf, default_key_schema=self.key_schema,
+                                     default_value_schema=self.value_schema)
+
+    def load_schema(self, schema_file: str):
+        try:
+            from confluent_kafka import avro
+            file = open(schema_file, "r")
+            schema_bytes = file.read()
+            file.close()
+            return avro.loads(schema_bytes)
+        except Exception as e:
+            self.logger.error(f"Exception occurred while loading the schema: {schema_file}: {e}")
+            self.logger.error(traceback.format_exc())
 
     def set_logger(self, logger):
         """
@@ -68,34 +85,12 @@ class AvroProducerApi(Base):
             This allows the original contents to be included for debugging purposes.
         """
         if err is not None:
-            self.log_error('Message {} delivery failed for user {} with error {}'.format(
-                obj.id, obj.name, err))
+            self.logger.error(f"KAFKA: Message {obj.id} delivery failed for {obj.name} with error {err}")
         else:
-            self.log_debug('Message {} successfully produced to {} [{}] at offset {}'.format(
-                obj.id, msg.topic(), msg.partition(), msg.offset()))
+            self.logger.debug(f"KAFKA: Message {obj.id} key {msg.key()} successfully produced to {msg.topic()} "
+                              f"[{msg.partition()}] at offset {msg.offset()}")
 
-    def produce_async(self, topic, record: IMessageAvro) -> bool:
-        """
-            Produce records for a specific topic
-            :param topic: topic to which messages are written to
-            :param record: record/message to be written
-            :return:
-        """
-        self.log_debug("Producing records to topic {}.".format(topic))
-        try:
-            # The message passed to the delivery callback will already be serialized.
-            # To aid in debugging we provide the original object to the delivery callback.
-            self.producer.produce(topic=topic, key=record.get_id(), value=record.to_dict(),
-                                  callback=lambda err, msg, obj=record: self.delivery_report(err, msg, obj))
-            # Serve on_delivery callbacks from previous asynchronous produce()
-            self.producer.poll(0)
-            return True
-        except ValueError as ex:
-            traceback.print_exc()
-            self.log_error("Invalid input, discarding record...{}".format(ex))
-        return False
-
-    def produce_sync(self, topic, record: IMessageAvro) -> bool:
+    def produce(self, topic, record: IMessageAvro) -> bool:
         """
             Produce records for a specific topic
             :param topic: topic to which messages are written to
@@ -103,54 +98,75 @@ class AvroProducerApi(Base):
             :return:
         """
         try:
-            self.log_debug("Record type={}".format(type(record)))
-            self.log_debug("Producing key {} to topic {}.".format(record.get_id(), topic))
-            self.log_debug("Producing record {} to topic {}.".format(record.to_dict(), topic))
+            self.logger.debug(f"KAFKA: Record type={type(record)}")
+            self.logger.debug(f"KAFKA: Producing key {record.get_id()} to topic {topic}.")
+            self.logger.debug(f"KAFKA: Producing record {record.to_dict()} to topic {topic}.")
 
             # Pass the message synchronously
-            self.producer.produce(topic=topic, key=record.get_id(), value=record.to_dict())
+            self.producer.produce(topic=topic, key=record.get_id(), value=record.to_dict(),
+                                  callback=lambda err, msg, obj=record: self.delivery_report(err, msg, obj))
+            self.producer.poll(0.0)
             self.producer.flush()
             return True
         except ValueError as ex:
-            self.log_error("Invalid input, discarding record...")
-            self.logger.error(f"Exception occurred {ex}")
+            self.logger.error("KAFKA: Invalid input, discarding record...")
+            self.logger.error(f"KAFKA: Exception occurred {ex}")
             self.logger.error(traceback.format_exc())
         except Exception as ex:
-            self.logger.error(f"Exception occurred {ex}")
+            self.logger.error(f"KAFKA: Exception occurred {ex}")
             self.logger.error(traceback.format_exc())
         return False
 
 
 if __name__ == '__main__':
-    from confluent_kafka import avro
+    from confluent_kafka import avro, SerializingProducer
 
     # Create Admin API object
-    api = AdminApi("localhost:9092")
+    conf = {'metadata.broker.list': 'localhost:19092',
+            'security.protocol': 'SSL',
+            'ssl.ca.location': '../../secrets/snakeoil-ca-1.crt',
+            'ssl.key.location': '../../secrets/kafkacat.client.key',
+            'ssl.key.password': 'confluent',
+            'ssl.certificate.location': '../../secrets/kafkacat-ca1-signed.pem'}
+
+    api = AdminApi(conf=conf)
     topics = ['topic1']
 
     # create topics
     api.create_topics(topics)
 
-    test_conf = {'bootstrap.servers': "localhost:9092",
-                 'schema.registry.url': "http://localhost:8081"}
+    test_key_schema = "schema/key.avsc"
+    test_val_schema = "schema/message.avsc"
 
-    # load AVRO schema
-    test_key_schema = avro.loads(open('schema/key.avsc', "r").read())
-    test_val_schema = avro.loads(open('schema/message.avsc', "r").read())
+    producer_conf = conf.copy()
+    producer_conf['schema.registry.url'] = "http://localhost:8081"
 
     # create a producer
-    producer = AvroProducerApi(test_conf, test_key_schema, test_val_schema)
+    producer = AvroProducerApi(producer_conf=producer_conf, key_schema_location=test_key_schema,
+                               value_schema_location=test_val_schema)
 
     # produce message to topics
-    message = QueryAvro()
-    message.message_id = "msg1"
-    message.properties = {"abc": "def"}
-    producer.produce_sync("topic1", message)
+    id_token = 'id_token'
 
-    message = QueryResultAvro()
-    message.message_id = "msg2"
-    message.properties = {"abc": "def"}
-    producer.produce_sync("topic1", message)
+    auth = AuthAvro()
+    auth.guid = "testguid"
+    auth.name = "testactor"
+    auth.oidc_sub_claim = "test-oidc"
+
+    query = QueryAvro()
+    query.message_id = "msg1"
+    query.callback_topic = "topic"
+    query.properties = {"abc": "def"}
+    query.auth = auth
+    query.id_token = id_token
+    producer.produce("topic1", query)
+
+    query_result = QueryResultAvro()
+    query_result.message_id = "msg2"
+    query_result.request_id = "req2"
+    query_result.properties = {"abc": "def"}
+    query_result.auth = auth
+    producer.produce("topic1", query_result)
 
     # delete topics
     api.delete_topics(topics)

--- a/fabric_mb/message_bus/test/message_bus_test.py
+++ b/fabric_mb/message_bus/test/message_bus_test.py
@@ -115,7 +115,7 @@ class MessageBusTest(unittest.TestCase):
                 'ssl.key.password': 'confluent',
                 'ssl.certificate.location': '../../../secrets/kafkacat-ca1-signed.pem'}
         # Create Admin API object
-        api = AdminApi(conf)
+        api = AdminApi(conf=conf)
 
         for a in api.list_topics():
             print("Topic {}".format(a))
@@ -127,19 +127,14 @@ class MessageBusTest(unittest.TestCase):
         api.create_topics(topics, num_partitions=1, replication_factor=1)
 
         # load AVRO schema
-        file = open('../schema/key.avsc', "r")
-        key_bytes = file.read()
-        file.close()
-        key_schema = avro.loads(key_bytes)
-        file = open('../schema/message.avsc', "r")
-        val_bytes = file.read()
-        file.close()
-        val_schema = avro.loads(val_bytes)
+        key_schema = "../schema/key.avsc"
+        value_schema = "../schema/message.avsc"
 
         conf['schema.registry.url'] = "http://localhost:8081"
 
         # create a producer
-        producer = AvroProducerApi(conf, key_schema, val_schema)
+        producer = AvroProducerApi(producer_conf=conf, key_schema_location=key_schema,
+                                   value_schema_location=value_schema)
 
         # push messages to topics
 
@@ -162,7 +157,7 @@ class MessageBusTest(unittest.TestCase):
         query.auth = auth
         query.id_token = id_token
         #print(query.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test1", query)
+        producer.produce("fabric_mb-mb-public-test1", query)
 
         # query_result
         query_result = QueryResultAvro()
@@ -171,7 +166,7 @@ class MessageBusTest(unittest.TestCase):
         query_result.properties = {"abc": "def"}
         query_result.auth = auth
         #print(query_result.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test2", query_result)
+        producer.produce("fabric_mb-mb-public-test2", query_result)
 
         # FailedRPC
         failed_rpc = FailedRpcAvro()
@@ -182,7 +177,7 @@ class MessageBusTest(unittest.TestCase):
         failed_rpc.error_details = "test error message"
         failed_rpc.auth = auth
         #print(failed_rpc.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test2", failed_rpc)
+        producer.produce("fabric_mb-mb-public-test2", failed_rpc)
 
         claim_req = ClaimResourcesAvro()
         claim_req.guid = "dummy-guid"
@@ -196,7 +191,7 @@ class MessageBusTest(unittest.TestCase):
         claim_req.id_token = id_token
 
         #print(claim_req.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test2", claim_req)
+        producer.produce("fabric_mb-mb-public-test2", claim_req)
 
         reservation = ReservationAvro()
         reservation.reservation_id = "res123"
@@ -259,7 +254,7 @@ class MessageBusTest(unittest.TestCase):
         claimd.delegation = delegation
         claimd.id_token = id_token
         #print(claim.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test2", claimd)
+        producer.produce("fabric_mb-mb-public-test2", claimd)
 
         # redeem
         redeem = RedeemAvro()
@@ -268,7 +263,7 @@ class MessageBusTest(unittest.TestCase):
         redeem.reservation = reservation
         redeem.auth = auth
         #print(redeem.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test2", redeem)
+        producer.produce("fabric_mb-mb-public-test2", redeem)
 
         update_ticket = UpdateTicketAvro()
         update_ticket.auth = auth
@@ -280,7 +275,7 @@ class MessageBusTest(unittest.TestCase):
         update_ticket.update_data.message = ""
 
         #print(update_ticket.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test2", update_ticket)
+        producer.produce("fabric_mb-mb-public-test2", update_ticket)
 
         update_d = UpdateDelegationAvro()
         update_d.auth = auth
@@ -293,7 +288,7 @@ class MessageBusTest(unittest.TestCase):
         update_d.id_token = id_token
 
         #print(update_ticket.to_dict())
-        producer.produce_sync("fabric_mb-mb-public-test2", update_d)
+        producer.produce("fabric_mb-mb-public-test2", update_d)
 
         get_slice = GetSlicesRequestAvro()
         get_slice.auth = auth
@@ -304,7 +299,7 @@ class MessageBusTest(unittest.TestCase):
 
         #print(get_slice.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", get_slice)
+        producer.produce("fabric_mb-mb-public-test2", get_slice)
 
         result = ResultAvro()
         result.code = 0
@@ -329,7 +324,7 @@ class MessageBusTest(unittest.TestCase):
 
         #print(slice_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", slice_res)
+        producer.produce("fabric_mb-mb-public-test2", slice_res)
 
         res_req = GetReservationsRequestAvro()
         res_req.message_id = "abc123"
@@ -342,7 +337,7 @@ class MessageBusTest(unittest.TestCase):
 
         print(res_req.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", res_req)
+        producer.produce("fabric_mb-mb-public-test2", res_req)
 
         del_req = GetDelegationsAvro()
         del_req.message_id = "msg1"
@@ -354,7 +349,7 @@ class MessageBusTest(unittest.TestCase):
 
         print(del_req.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", del_req)
+        producer.produce("fabric_mb-mb-public-test2", del_req)
 
         res = ReservationMng()
         res.reservation_id = "abcd123"
@@ -376,7 +371,7 @@ class MessageBusTest(unittest.TestCase):
 
         #print(res_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", res_res)
+        producer.produce("fabric_mb-mb-public-test2", res_res)
 
         remove_slice = RemoveSliceAvro()
         remove_slice.message_id = "msg1"
@@ -386,14 +381,14 @@ class MessageBusTest(unittest.TestCase):
         remove_slice.auth = auth
         #print(remove_slice.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", remove_slice)
+        producer.produce("fabric_mb-mb-public-test2", remove_slice)
 
         status_resp = ResultStringAvro()
         status_resp.message_id = "msg1"
         status_resp.result = "abc"
         status_resp.status = result
 
-        producer.produce_sync("fabric_mb-mb-public-test2", status_resp)
+        producer.produce("fabric_mb-mb-public-test2", status_resp)
 
         add_slice = AddSliceAvro()
         add_slice.message_id = "msg1"
@@ -403,7 +398,7 @@ class MessageBusTest(unittest.TestCase):
         add_slice.auth = auth
         # print(add_slice.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", add_slice)
+        producer.produce("fabric_mb-mb-public-test2", add_slice)
 
         update_slice = UpdateSliceAvro()
         update_slice.message_id = "msg1"
@@ -413,7 +408,7 @@ class MessageBusTest(unittest.TestCase):
         update_slice.auth = auth
         # print(update_slice.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", update_slice)
+        producer.produce("fabric_mb-mb-public-test2", update_slice)
 
         remove_res = RemoveReservationAvro()
         remove_res.message_id = "msg1"
@@ -423,7 +418,7 @@ class MessageBusTest(unittest.TestCase):
         remove_res.auth = auth
         # print(remove_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", remove_res)
+        producer.produce("fabric_mb-mb-public-test2", remove_res)
 
         close_res = CloseReservationsAvro()
         close_res.message_id = "msg1"
@@ -433,7 +428,7 @@ class MessageBusTest(unittest.TestCase):
         close_res.auth = auth
         # print(close_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", close_res)
+        producer.produce("fabric_mb-mb-public-test2", close_res)
 
         update_res = UpdateReservationAvro()
         update_res.message_id = "msg1"
@@ -443,7 +438,7 @@ class MessageBusTest(unittest.TestCase):
         update_res.auth = auth
         print(update_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", update_res)
+        producer.produce("fabric_mb-mb-public-test2", update_res)
 
         ticket = TicketReservationAvro()
         ticket.reservation_id = "abcd123"
@@ -465,7 +460,7 @@ class MessageBusTest(unittest.TestCase):
         add_res.auth = auth
         print(add_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", add_res)
+        producer.produce("fabric_mb-mb-public-test2", add_res)
 
         add_ress = AddReservationsAvro()
         add_ress.message_id = "msg1"
@@ -476,7 +471,7 @@ class MessageBusTest(unittest.TestCase):
         add_ress.auth = auth
         print(add_ress.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", add_ress)
+        producer.produce("fabric_mb-mb-public-test2", add_ress)
 
         demand_res = DemandReservationAvro()
         demand_res.message_id = "msg1"
@@ -486,7 +481,7 @@ class MessageBusTest(unittest.TestCase):
         demand_res.auth = auth
         print(demand_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", demand_res)
+        producer.produce("fabric_mb-mb-public-test2", demand_res)
 
         extend_res = ExtendReservationAvro()
         extend_res.message_id = "msg1"
@@ -501,7 +496,7 @@ class MessageBusTest(unittest.TestCase):
         extend_res.end_time = int(datetime.now().timestamp())
         print(extend_res.to_dict())
 
-        producer.produce_sync("fabric_mb-mb-public-test2", extend_res)
+        producer.produce("fabric_mb-mb-public-test2", extend_res)
 
         close = CloseAvro()
         close.message_id = "msg1"
@@ -509,7 +504,7 @@ class MessageBusTest(unittest.TestCase):
         close.callback_topic = "topic1"
         close.auth = auth
 
-        producer.produce_sync("fabric_mb-mb-public-test2", close)
+        producer.produce("fabric_mb-mb-public-test2", close)
 
         extend_lease = ExtendLeaseAvro()
         extend_lease.message_id = "msg1"
@@ -517,7 +512,7 @@ class MessageBusTest(unittest.TestCase):
         extend_lease.callback_topic = "topic1"
         extend_lease.auth = auth
 
-        producer.produce_sync("fabric_mb-mb-public-test2", extend_lease)
+        producer.produce("fabric_mb-mb-public-test2", extend_lease)
 
         extend_ticket = ExtendTicketAvro()
         extend_ticket.message_id = "msg1"
@@ -525,7 +520,7 @@ class MessageBusTest(unittest.TestCase):
         extend_ticket.callback_topic = "topic1"
         extend_ticket.auth = auth
 
-        producer.produce_sync("fabric_mb-mb-public-test2", extend_ticket)
+        producer.produce("fabric_mb-mb-public-test2", extend_ticket)
 
         modify_lease = ModifyLeaseAvro()
         modify_lease.message_id = "msg1"
@@ -533,7 +528,7 @@ class MessageBusTest(unittest.TestCase):
         modify_lease.callback_topic = "topic1"
         modify_lease.auth = auth
 
-        producer.produce_sync("fabric_mb-mb-public-test2", modify_lease)
+        producer.produce("fabric_mb-mb-public-test2", modify_lease)
 
         update_lease = UpdateLeaseAvro()
         update_lease.message_id = "msg1"
@@ -544,7 +539,7 @@ class MessageBusTest(unittest.TestCase):
         update_lease.update_data.message = "success"
         update_lease.auth = auth
 
-        producer.produce_sync("fabric_mb-mb-public-test2", update_lease)
+        producer.produce("fabric_mb-mb-public-test2", update_lease)
 
         ticket = TicketAvro()
         ticket.message_id = "msg1"
@@ -552,7 +547,7 @@ class MessageBusTest(unittest.TestCase):
         ticket.callback_topic = "topic1"
         ticket.auth = auth
 
-        producer.produce_sync("fabric_mb-mb-public-test2", ticket)
+        producer.produce("fabric_mb-mb-public-test2", ticket)
 
         res_state_req = GetReservationsStateRequestAvro()
         res_state_req.guid = "gud1"
@@ -563,7 +558,7 @@ class MessageBusTest(unittest.TestCase):
         res_state_req.auth = auth
         res_state_req.id_token = id_token
 
-        producer.produce_sync("fabric_mb-mb-public-test2", res_state_req)
+        producer.produce("fabric_mb-mb-public-test2", res_state_req)
 
         res_strings = ResultStringsAvro()
         res_strings.status = result
@@ -571,7 +566,7 @@ class MessageBusTest(unittest.TestCase):
         res_strings.result = []
         res_strings.result.append("r1")
 
-        producer.produce_sync("fabric_mb-mb-public-test2", res_strings)
+        producer.produce("fabric_mb-mb-public-test2", res_strings)
 
         res_state = ResultReservationStateAvro()
         res_state.status = result
@@ -580,9 +575,10 @@ class MessageBusTest(unittest.TestCase):
         ss = ReservationStateAvro()
         ss.state = 1
         ss.pending_state = 2
+        ss.rid = "rid1"
         res_state.reservation_states.append(ss)
 
-        producer.produce_sync("fabric_mb-mb-public-test2", res_state)
+        producer.produce("fabric_mb-mb-public-test2", res_state)
 
         ru = GetReservationUnitsRequestAvro()
         ru.message_id = "msg1"
@@ -593,7 +589,7 @@ class MessageBusTest(unittest.TestCase):
         ru.callback_topic = "test"
         ru.id_token = id_token
 
-        producer.produce_sync("fabric_mb-mb-public-test2", ru)
+        producer.produce("fabric_mb-mb-public-test2", ru)
 
         ruu = GetUnitRequestAvro()
         ruu.message_id = "msg1"
@@ -604,7 +600,7 @@ class MessageBusTest(unittest.TestCase):
         ruu.callback_topic = "test"
         ruu.id_token = id_token
 
-        producer.produce_sync("fabric_mb-mb-public-test2", ruu)
+        producer.produce("fabric_mb-mb-public-test2", ruu)
 
         bqm_query = GetBrokerQueryModelRequestAvro()
         bqm_query.message_id = "msg1"
@@ -615,7 +611,7 @@ class MessageBusTest(unittest.TestCase):
         bqm_query.broker_id = "broker11"
         bqm_query.id_token = id_token
 
-        producer.produce_sync("fabric_mb-mb-public-test2", bqm_query)
+        producer.produce("fabric_mb-mb-public-test2", bqm_query)
 
         actors_req = GetActorsRequestAvro()
         actors_req.message_id = "msg1"
@@ -626,7 +622,7 @@ class MessageBusTest(unittest.TestCase):
         actors_req.type = "Broker"
         actors_req.id_token = id_token
 
-        producer.produce_sync("fabric_mb-mb-public-test2", actors_req)
+        producer.produce("fabric_mb-mb-public-test2", actors_req)
 
         result_unit = ResultUnitsAvro()
         result_unit.message_id = "msg1"
@@ -634,7 +630,7 @@ class MessageBusTest(unittest.TestCase):
         result_unit.units = []
         result_unit.units.append(unit)
 
-        producer.produce_sync("fabric_mb-mb-public-test2", result_unit)
+        producer.produce("fabric_mb-mb-public-test2", result_unit)
 
         result_proxy = ResultProxyAvro()
         proxy = ProxyAvro()
@@ -648,7 +644,7 @@ class MessageBusTest(unittest.TestCase):
         result_proxy.proxies = []
         result_proxy.proxies.append(proxy)
 
-        producer.produce_sync("fabric_mb-mb-public-test2", result_proxy)
+        producer.produce("fabric_mb-mb-public-test2", result_proxy)
 
         result_model = ResultBrokerQueryModelAvro()
         result_model.model = BrokerQueryModelAvro()
@@ -658,7 +654,7 @@ class MessageBusTest(unittest.TestCase):
         result_model.message_id = "msg1"
         result_model.status = result
 
-        producer.produce_sync("fabric_mb-mb-public-test2", result_model)
+        producer.produce("fabric_mb-mb-public-test2", result_model)
 
         result_actor = ResultActorAvro()
         actor = ActorAvro()
@@ -676,7 +672,7 @@ class MessageBusTest(unittest.TestCase):
         result_actor.actors = []
         result_actor.actors.append(actor)
 
-        producer.produce_sync("fabric_mb-mb-public-test2", result_actor)
+        producer.produce("fabric_mb-mb-public-test2", result_actor)
 
         # Fallback to earliest to ensure all messages are consumed
         conf['auto.offset.reset'] = "earliest"
@@ -812,11 +808,12 @@ class MessageBusTest(unittest.TestCase):
 
         # create a consumer
         conf['group.id'] = 'ssl-host'
-        consumer = TestConsumer(conf, key_schema, val_schema, topics)
+        consumer = TestConsumer(consumer_conf=conf, key_schema_location=key_schema,
+                                value_schema_location=value_schema, topics=topics)
         consumer.set_parent(self)
 
         # start a thread to consume messages
-        consume_thread = Thread(target=consumer.consume_auto, daemon=True)
+        consume_thread = Thread(target=consumer.consume, daemon=True)
 
         consume_thread.start()
         time.sleep(10)


### PR DESCRIPTION
Issue# 
- Some of the messages even though in logs are indicated to be written successfully to the topic are not found in the topic dump
- Confluent Kafka python library indicates that the producer and consumer are thread safe. But based on the test observations, they don't appear to be thread safe
Solution#
- Reorganized the classes to move logger and logging messages
- Introduced thread safety in the producer
- Moved the schema inside producer/consumer
Observations#
- Patch applied on RENCI and haven't observed any missed messages since 4 days

https://github.com/fabric-testbed/MessageBusSchema/issues/21